### PR TITLE
Add tests for forceRepayRPL and forceRepayETH and fix issues found

### DIFF
--- a/contracts/rocketlend.vy
+++ b/contracts/rocketlend.vy
@@ -423,12 +423,12 @@ def forceRepayETH(_poolId: bytes32, _node: address):
   self._checkFromLender(_poolId)
   self._checkEndedOwing(_poolId, _node)
   ethPerRpl: uint256 = staticcall self._getRocketNetworkPrices().getRPLPrice()
-  startAmount: uint256 = self.borrowers[_node].ETH
-  amount: uint256 = startAmount - self._payDebt(_poolId, _node, startAmount // ethPerRpl) * ethPerRpl
-  assert 0 < amount, "none"
-  self.borrowers[_node].ETH -= amount
-  self.pools[_poolId].reclaimed += amount
-  log ForceRepayETH(_poolId, _node, amount, self.borrowers[_node].ETH, self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
+  startAmountETH: uint256 = self.borrowers[_node].ETH
+  endAmountETH: uint256 = (self._payDebt(_poolId, _node, (startAmountETH * oneEther) // ethPerRpl) * ethPerRpl) // oneEther
+  assert 0 < endAmountETH, "none"
+  self.borrowers[_node].ETH = endAmountETH
+  self.pools[_poolId].reclaimed += (startAmountETH - endAmountETH)
+  log ForceRepayETH(_poolId, _node, endAmountETH, self.borrowers[_node].ETH, self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
 
 @external
 def forceClaimMerkleRewards(
@@ -475,12 +475,12 @@ def forceDistributeRefund(_poolId: bytes32, _node: address,
   total += self._refundMinipools(_refundMinipools)
   assert 0 < total, "none"
   ethPerRpl: uint256 = staticcall self._getRocketNetworkPrices().getRPLPrice()
-  startAmount: uint256 = self.borrowers[_node].ETH
-  amount: uint256 = startAmount - self._payDebt(_poolId, _node, startAmount // ethPerRpl) * ethPerRpl
-  assert 0 < amount, "none"
-  self.borrowers[_node].ETH -= amount
-  self.pools[_poolId].reclaimed += amount
-  log ForceDistributeRefund(_poolId, _node, total, amount, self.borrowers[_node].ETH,
+  startAmountETH: uint256 = self.borrowers[_node].ETH
+  endAmountETH: uint256 = (self._payDebt(_poolId, _node, (startAmountETH * oneEther) // ethPerRpl) * ethPerRpl) // oneEther
+  assert 0 < endAmountETH, "none"
+  self.borrowers[_node].ETH = endAmountETH
+  self.pools[_poolId].reclaimed += (startAmountETH - endAmountETH)
+  log ForceDistributeRefund(_poolId, _node, total, endAmountETH, self.borrowers[_node].ETH,
                             self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
 
 @internal

--- a/contracts/rocketlend.vy
+++ b/contracts/rocketlend.vy
@@ -425,10 +425,11 @@ def forceRepayETH(_poolId: bytes32, _node: address):
   ethPerRpl: uint256 = staticcall self._getRocketNetworkPrices().getRPLPrice()
   startAmountETH: uint256 = self.borrowers[_node].ETH
   endAmountETH: uint256 = (self._payDebt(_poolId, _node, (startAmountETH * oneEther) // ethPerRpl) * ethPerRpl) // oneEther
-  assert 0 < endAmountETH, "none"
+  reclaimedETH: uint256 = startAmountETH - endAmountETH
+  assert 0 < reclaimedETH, "none"
   self.borrowers[_node].ETH = endAmountETH
-  self.pools[_poolId].reclaimed += (startAmountETH - endAmountETH)
-  log ForceRepayETH(_poolId, _node, endAmountETH, self.borrowers[_node].ETH, self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
+  self.pools[_poolId].reclaimed += reclaimedETH
+  log ForceRepayETH(_poolId, _node, reclaimedETH, self.borrowers[_node].ETH, self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
 
 @external
 def forceClaimMerkleRewards(
@@ -477,10 +478,12 @@ def forceDistributeRefund(_poolId: bytes32, _node: address,
   ethPerRpl: uint256 = staticcall self._getRocketNetworkPrices().getRPLPrice()
   startAmountETH: uint256 = self.borrowers[_node].ETH
   endAmountETH: uint256 = (self._payDebt(_poolId, _node, (startAmountETH * oneEther) // ethPerRpl) * ethPerRpl) // oneEther
-  assert 0 < endAmountETH, "none"
+
+  reclaimedETH: uint256 = startAmountETH - endAmountETH
+  assert 0 < reclaimedETH, "none"
   self.borrowers[_node].ETH = endAmountETH
-  self.pools[_poolId].reclaimed += (startAmountETH - endAmountETH)
-  log ForceDistributeRefund(_poolId, _node, total, endAmountETH, self.borrowers[_node].ETH,
+  self.pools[_poolId].reclaimed += reclaimedETH
+  log ForceDistributeRefund(_poolId, _node, total, reclaimedETH, self.borrowers[_node].ETH,
                             self.borrowers[_node].borrowed, self.borrowers[_node].interestDue)
 
 @internal

--- a/tests/test_rocketlend.py
+++ b/tests/test_rocketlend.py
@@ -671,17 +671,15 @@ def test_force_repay_eth_not_ended(rocketlendp, borrower1b):
     with reverts('revert: term'):
         rocketlend.forceRepayETH(poolId, node, sender=lender)
 
-def test_force_eth_repay_not_enought_eth(rocketlendp, distributedRewards, chain, rocketVaultImpersonated, lender2, RPLToken, accounts):
-    node = distributedRewards['node']
-    rocketlend = distributedRewards['rocketlend']
+def test_force_eth_repay_noOp(rocketlendp, borrower1b, chain, rocketVaultImpersonated, lender2, RPLToken, accounts):
+    node = borrower1b['node']
+    rocketlend = rocketlendp['rocketlend']
     poolId = rocketlendp['poolId']
     lender = rocketlendp['lender']
     borrower = accounts[rocketlend.borrowers(node).address]
-    
-    amount = 250 * 10 ** RPLToken.decimals()
-    grab_RPL(lender2, amount, RPLToken, rocketVaultImpersonated, rocketlend)
-    rocketlend.supplyPool(poolId, amount, sender=lender2)
-    rocketlend.borrow(poolId, node, amount, sender=borrower)
+
+    # borrower has no ETH in rocketlend
+    assert rocketlend.borrowers(node).ETH == 0    
     
     # wait for pool to end
     chain.pending_timestamp += round(datetime.timedelta(weeks=2, days=1).total_seconds())

--- a/tests/test_rocketlend.py
+++ b/tests/test_rocketlend.py
@@ -659,6 +659,7 @@ def test_force_repay_rpl_not_ended(rocketlendp, borrower1b):
     with reverts('revert: term'):
         rocketlend.forceRepayRPL(poolId, node, 123, sender=lender)
 
+#### TODO add good repay test and validate amounts
 
 ### forceRepayETH
 

--- a/tests/test_rocketlend.py
+++ b/tests/test_rocketlend.py
@@ -644,13 +644,6 @@ def test_withdraw_ether_from_pool_none(rocketlendp):
 
 ### forceRepayRPL
 
-def test_force_repay_rpl_other(rocketlendp, borrower1b, other):
-    rocketlend = rocketlendp['rocketlend']
-    poolId = rocketlendp['poolId']
-    node = borrower1b['node']
-    with reverts('revert: auth'):
-        rocketlend.forceRepayRPL(poolId, node, 123, sender=other)
-
 def test_force_repay_rpl_not_ended(rocketlendp, borrower1b):
     rocketlend = rocketlendp['rocketlend']
     poolId = rocketlendp['poolId']


### PR DESCRIPTION
This adds the following tests for forceRepayRPL:
- test_force_repay_rpl_other: verify revert on wrong sender
- test_force_repay_rpl_not_ended: verify revert on term not over

This adds the following tests for forceRepayETH:
- test_force_repay_eth_other: verify revert on wrong sender
- test_force_repay_eth_not_ended: verify revert on term not over
- test_force_eth_repay_not_enought_eth: verify revert on not enough ETH available
- test_force_eth_repay: good test, verify amounts
   - Notice: lines 711-713 borrow 1 wei RPL to update the interest (afaik there is no better way to trigger an update)
   - Notice: line 727 checks for close to expected amount as debt increases each second
   
This updates the contract functions forceRepayETH and forceClaimMerkleRewards:
- self._payDebt(..) returns what is left over from the amount 
  - compare how [forceRepayRPL](https://github.com/rocketlend/protocol/blob/e080f3b95f90281dc8c02b1f1bf352bc1b0b8ad6/contracts/rocketlend.vy#L416) handles the result)
- ethPerRpl is scaled to 18 decimals. Update the conversions to account for that. 
  - compare how [_borrowLimit](https://github.com/rocketlend/protocol/blob/e080f3b95f90281dc8c02b1f1bf352bc1b0b8ad6/contracts/rocketlend.vy#L718-L723) converts ETH to RPL