### PR TITLE
Fix: remove pending borrower address when leaving

### DIFF
--- a/contracts/rocketlend.vy
+++ b/contracts/rocketlend.vy
@@ -634,6 +634,7 @@ def leaveAsBorrower(_node: address):
   extcall rocketStorage.setWithdrawalAddress(_node, msg.sender, True)
   extcall self._getRocketNodeManager().unsetRPLWithdrawalAddress(_node)
   self.borrowers[_node].address = empty(address)
+  self.borrowers[_node].pending = empty(address)
   log LeaveProtocol(_node)
 
 @internal

--- a/tests/test_rocketlend.py
+++ b/tests/test_rocketlend.py
@@ -784,6 +784,24 @@ def test_change_borrower_to_other_force(borrower1, other):
     assert len(logs) == 1
     assert logs[0].new == other
 
+def test_change_borrower_2_step_leave_early(rocketlendp, rocketStorage, borrower1, other):
+    rocketlend = rocketlendp['rocketlend']
+    borrower = borrower1['borrower']
+    node = borrower1['node']
+
+    # start 2-step borrower address change
+    rocketlend.changeBorrowerAddress(node, other, False, sender=borrower)
+
+    rocketlend.leaveAsBorrower(node, sender=borrower)
+
+    # withdraw address was changed back to borrower
+    assert rocketStorage.getNodeWithdrawalAddress(node) == borrower
+
+    # accept the change
+    with reverts('revert: auth'):
+        rocketlend.confirmChangeBorrowerAddress(node, sender=other)
+
+
 ### joinAsBorrower
 
 def test_join_protocol_wrong_pending(rocketlendp, node1):


### PR DESCRIPTION
When a borrower calls `leaveAsBorrower` it only resets the current address. With a pending borrow address change, `confirmChangeBorrowerAddress` will still pass (`msg.sender == self.borrowers[_node].pending`). That way the borrower can set the address again. Therefore he can use rocketlend to borrow without having his withdraw address set to the protocol address.

Consider this testcase:

```python
def test_change_borrower_2_step_leave_early(rocketlendp, rocketStorage, rocketNodeDeposit, rocketNodeStaking, RPLToken, borrower1, other):
    rocketlend = rocketlendp['rocketlend']
    poolId = rocketlendp['poolId']
    borrower = borrower1['borrower']
    node = borrower1['node']

    # start 2-step borrower address change
    rocketlend.changeBorrowerAddress(node, other, False, sender=borrower)

    rocketlend.leaveAsBorrower(node, sender=borrower)

    # withdraw address was changed back to borrower
    assert rocketStorage.getNodeWithdrawalAddress(node) == borrower

    # accept the change
    rocketlend.confirmChangeBorrowerAddress(node, sender=other)

    # allow staking, rocketlend no longer the withdraw address
    rocketNodeStaking.setStakeRPLForAllowed(node, rocketlend, True, sender=node)

    prev_stake = rocketNodeStaking.getNodeRPLStake(node)
    
    amount = 50 * 10 ** RPLToken.decimals()
    rocketNodeDeposit.depositEthFor(node, value='8 ether', sender=other)
    rocketlend.borrow(poolId, node, amount, sender=other)

    assert rocketStorage.getNodeWithdrawalAddress(node) == borrower
    assert rocketNodeStaking.getNodeRPLStake(node) == prev_stake + amount
```

This PR adds a fix for that issue and a testcase. By resetting the pending address as well, the function `confirmChangeBorrowerAddress` can not be called after leaving rocketlend.